### PR TITLE
Add shotgun surgery, update feature envy, add abstract class tester.

### DIFF
--- a/src/main/java/com/CodeSmell/smell/FeatureEnvy.java
+++ b/src/main/java/com/CodeSmell/smell/FeatureEnvy.java
@@ -1,14 +1,14 @@
 package com.CodeSmell.smell;
 
 import com.CodeSmell.parser.*;
+import com.CodeSmell.stat.Helper;
+import com.CodeSmell.stat.MethodStat;
 
-import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Map;
+import java.util.*;
 
 public class FeatureEnvy extends Smell {
+
+    private static final int ENVY_THRESHOLD = 3;
     public LinkedList<CodeFragment> detections;
     protected FeatureEnvy( CodePropertyGraph cpg) {
         super("Feature Envy", cpg);
@@ -42,47 +42,66 @@ public class FeatureEnvy extends Smell {
                     attrList.add(a);
                 }
                 for(CPGClass.Method m : method.getMethodCalls()){
-                    if(!m.returnType.equals("")) //void methods do not count
+
+                    if(!m.returnType.equals("") && !m.name.equals("main")) //void and main methods do not count
                         accessList.add(m);
                 }
             }
         }
-
 
         /* For each CPGClass, tally up a list of how many times it accesses:
         - any attribute from a given class, or
         - any method that returns something from a given class
         Then compare the tally for an external class for the tally for the class itself.
          */
-        for(Map.Entry<CPGClass, ArrayList<CPGClass.Method>> classEntry : methodAccesses.entrySet()){
-            Map<CPGClass, Integer> classCallCount = new HashMap<>();
-            for(CPGClass.Method methodEntry : classEntry.getValue()){
-                if(classCallCount.containsKey(methodEntry.getParent())){
-                    classCallCount.put(methodEntry.getParent(), classCallCount.get(methodEntry.getParent()) + 1);
-                }else{
-                    classCallCount.put(methodEntry.getParent(), 1);
+        for(Map.Entry<CPGClass, ArrayList<CPGClass.Method>> classEntry : methodAccesses.entrySet()) {
+
+            if (!classEntry.getKey().classType.equals("interface")){
+                Map<String, Integer> classCallCount = new HashMap<>();
+
+            for (CPGClass.Method methodEntry : classEntry.getValue()) {
+
+                int methodCallCount = 1;
+
+                if (classCallCount.containsKey(methodEntry.getParent().classFullName)) {
+                    classCallCount.put(methodEntry.getParent().classFullName, classCallCount.get(methodEntry.getParent().classFullName) + methodCallCount);
+                } else {
+                    classCallCount.put(methodEntry.getParent().classFullName, methodCallCount);
                 }
             }
-            for(CPGClass.Attribute attrEntry : attrAccesses.get(classEntry.getKey())){
-                if(classCallCount.containsKey(attrEntry.getParent())){
-                    classCallCount.put(attrEntry.getParent(), classCallCount.get(attrEntry.getParent()) + 1);
+            for (CPGClass.Attribute attrEntry : attrAccesses.get(classEntry.getKey())) {
+                int attrCallCount = 1;
+                String targetClass;
+                if(classCallCount.containsKey(attrEntry.attributeType)){
+                    targetClass = attrEntry.attributeType;
                 }else{
-                    classCallCount.put(attrEntry.getParent(), 1);
+                    targetClass = attrEntry.getParent().classFullName;
+                }
+
+                if (classCallCount.containsKey(targetClass)){
+                    classCallCount.put(targetClass, classCallCount.get(targetClass) + attrCallCount);
+                } else {
+                    classCallCount.put(targetClass, attrCallCount);
                 }
             }
             //figure out how many calls of its own fields the class has
             int ownCallCount;
-            if(classCallCount.containsKey(classEntry.getKey()))
-                ownCallCount = classCallCount.get(classEntry.getKey());
+            if (classCallCount.containsKey(classEntry.getKey().classFullName))
+                ownCallCount = classCallCount.get(classEntry.getKey().classFullName);
             else
                 ownCallCount = 0;
-
-            for(Map.Entry<CPGClass, Integer> countEntry : classCallCount.entrySet()){
-                if(countEntry.getValue() > ownCallCount){
-                    this.addSmell(classEntry.getKey(), countEntry.getKey(), countEntry.getValue(), ownCallCount);
+            for (Map.Entry<String, Integer> countEntry : classCallCount.entrySet()) {
+                if (countEntry.getValue() > ownCallCount && countEntry.getValue() > ENVY_THRESHOLD) {
+                    CPGClass theClass = null;
+                    for(CPGClass c : cpg.getClasses()){
+                        if(c.classFullName == countEntry.getKey())
+                            theClass = c;
+                    }
+                    this.addSmell(classEntry.getKey(), theClass, countEntry.getValue(), ownCallCount);
                 }
             }
 
+        }
         }
 
     }

--- a/src/main/java/com/CodeSmell/smell/ShotgunSurgery.java
+++ b/src/main/java/com/CodeSmell/smell/ShotgunSurgery.java
@@ -25,24 +25,16 @@ public class ShotgunSurgery extends Smell {
     private void detectAll(){
         ArrayList<CPGClass> classes = cpg.getClasses();
 
-        Map<CPGClass.Method, ArrayList<CPGClass.Method>> callMethods = new HashMap<CPGClass.Method, ArrayList<CPGClass.Method>>();
-        Map<CPGClass.Method, ArrayList<CPGClass>> callClasses = new HashMap<CPGClass.Method, ArrayList<CPGClass>>();
-
-        //Map<CPGClass.Method, CPGClass> methodClasses = new HashMap<CPGClass.Method, CPGClass>();
-
         //first, build the dictionaries
         for(CPGClass curClass : classes){
             for(CPGClass.Method curMethod : curClass.getMethods()){
 
                 MethodStat mStat = new MethodStat(curMethod, cpg, new Helper(cpg));
-
-                int methodCallsSize = 0;
                 ArrayList<CPGClass> classCalls = new ArrayList<>();
                 ArrayList<CPGClass.Method> methodCalls = new ArrayList<>();
                 //build lists of classes this method calls, and number of methods this calls
-
                 for(Map.Entry<CPGClass, List<CPGClass.Method>> entry : mStat.distinctMethodCalls.entrySet()){
-                    methodCallsSize += entry.getValue().size();
+
                     for(CPGClass.Method m : entry.getValue()){
                         methodCalls.add(m);
                         if(!classCalls.contains(m.getParent())){
@@ -50,13 +42,11 @@ public class ShotgunSurgery extends Smell {
                         }
                     }
                 }
-                //System.out.println("   distinctMethodCalls size: " + methodCallsSize);
-                //System.out.println("   classCalls size: " + classCalls.size());
-                if((methodCallsSize >= CALLING_METHOD_CAP)
+                //check to see if it hits the main thresholds, if so, add a smell
+                if((methodCalls.size() >= CALLING_METHOD_CAP)
                     && (classCalls.size() >= CALLING_CLASS_CAP)){
                     this.addSmell(curMethod, methodCalls, classCalls, curClass);
                 }
-
             }
         }
     }
@@ -66,7 +56,7 @@ public class ShotgunSurgery extends Smell {
      * @param method the Method in question that has the shotgun surgery smell
      */
     private void addSmell(CPGClass.Method method, ArrayList<CPGClass.Method> callMethods, ArrayList<CPGClass> callClasses, CPGClass parentClass){
-        String description = method.getParent().classFullName + "." + method.name + " may have shotgun surgery.\n"
+        String description = method.getParent().classFullName + "." + method.name + " may have shotgun surgery, making it difficult.\n"
                 + method.name + " references " + callClasses.size() + " classes and " + callMethods.size() + " methods.\n"
                 + "It may make use of too many different functions and classes to define its functionality.";
         CodeFragment fragment = new CodeFragment(description, new CPGClass[]{parentClass}, new CPGClass.Method[]{method}, null, null, null, null);
@@ -75,6 +65,6 @@ public class ShotgunSurgery extends Smell {
 
     @Override
     public String description() {
-        return "A feature that is implemented or used in many different locations simultaneously.";
+        return "A feature whose behavior is defined in many different classes and methods, making it difficult to modify.";
     }
 }

--- a/src/main/java/com/CodeSmell/smell/ShotgunSurgery.java
+++ b/src/main/java/com/CodeSmell/smell/ShotgunSurgery.java
@@ -1,0 +1,80 @@
+package com.CodeSmell.smell;
+
+import com.CodeSmell.parser.*;
+import com.CodeSmell.stat.Helper;
+import com.CodeSmell.stat.MethodStat;
+
+import java.util.*;
+
+public class ShotgunSurgery extends Smell {
+
+    private static final int CALLING_METHOD_CAP = 10;
+    private static final int CALLING_CLASS_CAP = 5;
+    public LinkedList<CodeFragment> detections;
+    protected ShotgunSurgery(CodePropertyGraph cpg) {
+        super("Shotgun Surgery", cpg);
+        this.detections = new LinkedList<>();
+        detectAll();
+    }
+
+    @Override
+    public CodeFragment detectNext() {
+        return detections.poll();
+    }
+
+    private void detectAll(){
+        ArrayList<CPGClass> classes = cpg.getClasses();
+
+        Map<CPGClass.Method, ArrayList<CPGClass.Method>> callMethods = new HashMap<CPGClass.Method, ArrayList<CPGClass.Method>>();
+        Map<CPGClass.Method, ArrayList<CPGClass>> callClasses = new HashMap<CPGClass.Method, ArrayList<CPGClass>>();
+
+        //Map<CPGClass.Method, CPGClass> methodClasses = new HashMap<CPGClass.Method, CPGClass>();
+
+        //first, build the dictionaries
+        for(CPGClass curClass : classes){
+            for(CPGClass.Method curMethod : curClass.getMethods()){
+
+                MethodStat mStat = new MethodStat(curMethod, cpg, new Helper(cpg));
+
+                int methodCallsSize = 0;
+                ArrayList<CPGClass> classCalls = new ArrayList<>();
+                ArrayList<CPGClass.Method> methodCalls = new ArrayList<>();
+                //build lists of classes this method calls, and number of methods this calls
+
+                for(Map.Entry<CPGClass, List<CPGClass.Method>> entry : mStat.distinctMethodCalls.entrySet()){
+                    methodCallsSize += entry.getValue().size();
+                    for(CPGClass.Method m : entry.getValue()){
+                        methodCalls.add(m);
+                        if(!classCalls.contains(m.getParent())){
+                            classCalls.add(m.getParent());
+                        }
+                    }
+                }
+                //System.out.println("   distinctMethodCalls size: " + methodCallsSize);
+                //System.out.println("   classCalls size: " + classCalls.size());
+                if((methodCallsSize >= CALLING_METHOD_CAP)
+                    && (classCalls.size() >= CALLING_CLASS_CAP)){
+                    this.addSmell(curMethod, methodCalls, classCalls, curClass);
+                }
+
+            }
+        }
+    }
+
+    /**
+     *
+     * @param method the Method in question that has the shotgun surgery smell
+     */
+    private void addSmell(CPGClass.Method method, ArrayList<CPGClass.Method> callMethods, ArrayList<CPGClass> callClasses, CPGClass parentClass){
+        String description = method.getParent().classFullName + "." + method.name + " may have shotgun surgery.\n"
+                + method.name + " references " + callClasses.size() + " classes and " + callMethods.size() + " methods.\n"
+                + "It may make use of too many different functions and classes to define its functionality.";
+        CodeFragment fragment = new CodeFragment(description, new CPGClass[]{parentClass}, new CPGClass.Method[]{method}, null, null, null, null);
+        this.detections.add(fragment);
+    }
+
+    @Override
+    public String description() {
+        return "A feature that is implemented or used in many different locations simultaneously.";
+    }
+}

--- a/src/test/java/com/CodeSmell/smell/FeatureEnvyTest.java
+++ b/src/test/java/com/CodeSmell/smell/FeatureEnvyTest.java
@@ -12,16 +12,22 @@ import java.util.ArrayList;
 
 import static com.CodeSmell.smell.Common.initStatTracker;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
-public class FeatureEnvyTest {
+public class FeatureEnvyTest extends SmellTester{
 
-    private Parser p;
-    private CodePropertyGraph cpg;
+    //private Parser p;
+    //private CodePropertyGraph cpg;
+
+    //private FeatureEnvy fe;
+    //ArrayList<Smell.CodeFragment> detections;
 
     @Before
     public void before() {
         this.cpg = ProjectManager.getCPG("testproject");
         initStatTracker(cpg);
+        smell = new FeatureEnvy(this.cpg);
+        detections = getDetections(smell);
     }
 
     public ArrayList<Smell.CodeFragment> getDetections(Smell smell) {
@@ -32,12 +38,36 @@ public class FeatureEnvyTest {
         return arr;
     }
     @Test
-    public void TestFeatureEnvy(){
+    public void testWorksAtAll(){
         System.out.println("Feature Envy Test:");
-        FeatureEnvy fe = new FeatureEnvy(this.cpg);
-        ArrayList<Smell.CodeFragment> detections = getDetections(fe);
         System.out.println("   Number of detections: " + detections.size());
+        assertNotEquals(0, detections.size());
+    }
+
+    @Test
+    public void detectBasicEnvy(){
+        Smell.CodeFragment fragment = this.hasClass("FeatureEnvyer");
+        assertTrue(fragment != null);
+        if(fragment != null){
+            System.out.println(fragment.description);
+        }
+    }
+
+    @Test
+    public void detectOneMethodEnvy(){
+        Smell.CodeFragment fragment = this.hasClass("EnvierOneMethod");
+        assertTrue(fragment != null);
+        if(fragment != null){
+            System.out.println(fragment.description);
+        }
+    }
+
+    /*private boolean hasClass(String name){
+        boolean hasDetection = false;
         for(Smell.CodeFragment f : detections){
+            if(f.classes[0].classFullName.equals(name)){
+                hasDetection = true;
+            }
             if(f.classes.length > 0) {
                 String outLine = f.description + "\n";
                 outLine += "     Methods: {";
@@ -48,10 +78,8 @@ public class FeatureEnvyTest {
                 }
                 outLine += " }";
                 System.out.println(outLine);
-
             }
         }
-        assertNotEquals(0, detections.size());
-
-    }
+        return hasDetection;
+    }*/
 }

--- a/src/test/java/com/CodeSmell/smell/FeatureEnvyTest.java
+++ b/src/test/java/com/CodeSmell/smell/FeatureEnvyTest.java
@@ -16,11 +16,6 @@ import static org.junit.Assert.assertTrue;
 
 public class FeatureEnvyTest extends SmellTester{
 
-    //private Parser p;
-    //private CodePropertyGraph cpg;
-
-    //private FeatureEnvy fe;
-    //ArrayList<Smell.CodeFragment> detections;
 
     @Before
     public void before() {
@@ -52,7 +47,7 @@ public class FeatureEnvyTest extends SmellTester{
             System.out.println(fragment.description);
         }
     }
-
+    /*
     @Test
     public void detectOneMethodEnvy(){
         Smell.CodeFragment fragment = this.hasClass("EnvierOneMethod");
@@ -60,26 +55,6 @@ public class FeatureEnvyTest extends SmellTester{
         if(fragment != null){
             System.out.println(fragment.description);
         }
-    }
-
-    /*private boolean hasClass(String name){
-        boolean hasDetection = false;
-        for(Smell.CodeFragment f : detections){
-            if(f.classes[0].classFullName.equals(name)){
-                hasDetection = true;
-            }
-            if(f.classes.length > 0) {
-                String outLine = f.description + "\n";
-                outLine += "     Methods: {";
-                for(int n = 0; n < f.methods.length; n++){
-                    outLine += f.methods[n].name;
-                    if((n+1) < f.methods.length)
-                        outLine += ", ";
-                }
-                outLine += " }";
-                System.out.println(outLine);
-            }
-        }
-        return hasDetection;
     }*/
+
 }

--- a/src/test/java/com/CodeSmell/smell/ShotgunSurgeryTest.java
+++ b/src/test/java/com/CodeSmell/smell/ShotgunSurgeryTest.java
@@ -15,8 +15,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 public class ShotgunSurgeryTest extends SmellTester{
 
-
-
     @Before
     public void before() {
         this.cpg = ProjectManager.getCPG("testproject");

--- a/src/test/java/com/CodeSmell/smell/ShotgunSurgeryTest.java
+++ b/src/test/java/com/CodeSmell/smell/ShotgunSurgeryTest.java
@@ -1,0 +1,57 @@
+package com.CodeSmell.smell;
+
+import com.CodeSmell.ProjectManager;
+import com.CodeSmell.parser.CPGClass;
+import com.CodeSmell.parser.CodePropertyGraph;
+import com.CodeSmell.parser.Parser;
+import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static com.CodeSmell.smell.Common.initStatTracker;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+public class ShotgunSurgeryTest extends SmellTester{
+
+
+
+    @Before
+    public void before() {
+        this.cpg = ProjectManager.getCPG("testproject");
+        initStatTracker(cpg);
+        smell = new ShotgunSurgery(this.cpg);
+        detections = getDetections(smell);
+    }
+
+    public ArrayList<Smell.CodeFragment> getDetections(Smell smell) {
+        ArrayList<Smell.CodeFragment> arr = new ArrayList<Smell.CodeFragment>();
+        while (smell.detect()) {
+            arr.add(smell.lastDetection);
+        }
+        return arr;
+    }
+    @Test
+    public void testWorksAtAll(){
+        System.out.println("Shotgun Surgery Test: ");
+        System.out.println("   Number of detections: " + detections.size());
+        assertNotEquals(0, detections.size());
+    }
+
+    /**
+     * Detect if a basic shotgun surgery case is present.
+     *
+     * The basic case is a method that refers to the minimum number of other classes,
+     * and the minimum number of other methods, required to count as shotgun surgery.
+     */
+    @Test
+    public void detectBasicShotgunSurgery(){
+        Smell.CodeFragment fragment = this.hasMethod("ShotgunSurgeryClass", "basicShotgunMethod");
+        assertTrue(fragment != null);
+        if(fragment != null){
+            System.out.println(fragment.description);
+        }
+    }
+
+}

--- a/src/test/java/com/CodeSmell/smell/SmellTester.java
+++ b/src/test/java/com/CodeSmell/smell/SmellTester.java
@@ -1,0 +1,34 @@
+package com.CodeSmell.smell;
+
+import com.CodeSmell.parser.CodePropertyGraph;
+import com.CodeSmell.parser.Parser;
+
+import java.util.ArrayList;
+
+public abstract class SmellTester {
+
+    protected Parser p;
+    protected CodePropertyGraph cpg;
+
+    protected Smell smell;
+    ArrayList<Smell.CodeFragment> detections;
+
+    protected Smell.CodeFragment hasClass(String name){
+        for(Smell.CodeFragment f : detections){
+            if(f.classes[0].classFullName.equals(name)) {
+                return f;
+            }
+        }
+        return null;
+    }
+
+    protected Smell.CodeFragment hasMethod(String theClass, String theMethod){
+        //boolean hasDetection = false;
+        for(Smell.CodeFragment f : detections){
+            if(f.classes[0].classFullName.equals(theClass) && f.methods[0].name.equals(theMethod)) {
+                return f;
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/testproject/EnvierOneMethod.java
+++ b/src/test/java/com/testproject/EnvierOneMethod.java
@@ -1,0 +1,29 @@
+package com.testproject;
+
+public class EnvierOneMethod {
+    //Class to test if a class can have feature envy if all the envying only happens from calling one method.
+    int attr1;
+
+    public EnvierOneMethod(int a){
+        attr1 = a;
+    }
+
+    public int getAttr1(){
+        return this.attr1;
+    }
+
+    public void incrementAttr1(){
+        attr1++;
+    }
+
+    public int theMethod(){
+        FeatureEnvied envied = new FeatureEnvied(attr1);
+        envied.complexMethod(attr1, attr1*2);
+        for(int a = 0; a < 5; a++){
+            envied.complexMethod(attr1, attr1*2);
+        }
+        this.incrementAttr1();
+        envied.complexMethod(attr1, attr1*2);
+        return envied.complexMethod(attr1, attr1*2);
+    }
+}

--- a/src/test/java/com/testproject/FeatureEnvyer.java
+++ b/src/test/java/com/testproject/FeatureEnvyer.java
@@ -1,32 +1,33 @@
 package com.testproject;
 
 public class FeatureEnvyer {
-    private int field1, field2;
+    private int field1;
+    private FeatureEnvied field2;
 
     public FeatureEnvyer(int a, int b){
         field1 = a;
-        field2 = b;
+        field2 = new FeatureEnvied(b);
     }
     public int getField1() {
         return field1;
     }
 
-    public int getField2() {
+    /*public int getField2() {
         return field2;
-    }
+    }*/
 
-    public void setField2(int field2) {
+    /*public void setField2(int field2) {
         this.field2 = field2;
-    }
+    }*/
 
-    public int useEnvied1(){
+    public Integer useEnvied1(){
         FeatureEnvied n = new FeatureEnvied(this.field1);
 
-        return n.complexMethod(field1, field2);
+        return n.complexMethod(field1, field2.getAnInt());
     }
 
     public String envyString(){
-        int envyNumber = this.useEnvied1();
+        Integer envyNumber = this.useEnvied1();
         envyNumber = new FeatureEnvied(envyNumber).getAnInt() + 2;
         return new FeatureEnvied(envyNumber).aString;
     }

--- a/src/test/java/com/testproject/ShotgunSurgeryClass.java
+++ b/src/test/java/com/testproject/ShotgunSurgeryClass.java
@@ -1,0 +1,32 @@
+package com.testproject;
+
+public class ShotgunSurgeryClass {
+    private void internal1(){
+        System.out.println("foo");
+    }
+
+    private int internal2(int n){
+        return n+2;
+    }
+
+    private String internal3(){
+        return "bar";
+    }
+
+    /** Calls ten different functions and six different classes, including itself.
+     *
+     */
+    public void basicShotgunMethod(){
+
+        ClassA a = new ClassA();
+        a.addB(new ClassB(4));
+        ClassD d = new ClassD(a.getB());
+        d.doThing();
+        ClassE e = new ClassE();
+        GodClass g = new GodClass(new ClassA(), new ClassA());
+        if(g.compareAs() && g.compareB()){
+            System.out.println("foobar");
+        }
+
+    }
+}


### PR DESCRIPTION
This PR covers three main things. In order of importance:

**Shotgun Surgery**

Shotgun surgery is detected in this case by keeping track of both how many methods a given method calls, as well as how many actual classes a method calls. The reasoning behind this is that if, in order to change a method's functionality, we need to change everything that method may use, then a method that uses, say, five or six or more separate files to define itself is a method that is very difficult to modify in a centralized way. [This article](https://www.simpleorientedarchitecture.com/identify-shotgun-surgery-using-ndepend/) has more details and forms the basis for me using this method.
Currently, we check for methods that call at least 5 other classes and at least ten other methods. These are more or less arbitrary figures and subject to change. Currently the method is incapable of finding calls to methods within the same class as the method.

**Feature Envy**

I spent some time trying to clean up the behavior of the feature envy smell. In bullet point form:
- Feature envy now also checks attributes calls and sums attribute calls + method calls together. If ClassA uses ClassB.n a lot, that will show up.
- Feature envy no longer applies for interfaces.
- Feature envy no longer counts the main method either.

**Smell Tester Class**

This came while writing the test file for Shotgun Surgery. I already had a macro defined in FeatureEnvyTest for returning whether or not a given class was detected in the CPG, and expanded on that a bit and made FeatureEnvyTest and ShotgunSurgeryTest both inherit from an abstract 'SmellTester' class.